### PR TITLE
chore(issue-templates): complete setup and link tracking issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -1,0 +1,69 @@
+name: "Bug Report"
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please provide all required details below.
+
+  # Description 
+  - type: textarea
+    id: steps
+    attributes:
+      label: Description / Steps to reproduce
+      description: Explain the issue and how to reproduce it
+      placeholder: |
+        1. Go to ...
+        2. Click ...
+        3. See error
+    validations:
+      required: true
+
+  # Expected vs Actual behavior
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  # Screenshots 
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Drag & drop images or paste screenshots here 
+    validations:
+      required: false
+
+  # Environment info
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment / Version info
+      description: OS, browser, app version, device, etc.
+      placeholder: |
+        OS: Windows 11
+        Browser: Chrome 121
+        Version: 1.0.0
+    validations:
+      required: true
+
+  # Code of Conduct
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,61 @@
+name: "Feature Request"
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature. Please provide all details below.
+  
+  #Description
+  - type: textarea
+    id: description
+    attributes:
+      label: Description / Steps to reproduce
+    validations:
+      required: true
+
+  #Expected vs Actual behavior
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  # Screenshots
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Drag & drop images or paste screenshots here
+    validations:
+      required: false
+
+  
+  # Environment info
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment / Version info
+      description: OS, browser, app version, device, etc.
+    validations:
+      required: true
+
+   # Code of Conduct
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -7,51 +7,49 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for suggesting a feature. Please provide all details below.
-  
-  #Description
+        Thanks for suggesting a feature. Please provide the details below.
+
+  # Problem / Motivation
   - type: textarea
-    id: description
+    id: problem
     attributes:
-      label: Description / Steps to reproduce
+      label: Problem / Motivation
+      description: What problem or limitation would this feature address?
+      placeholder: Describe the challenge or pain point you are experiencing.
     validations:
       required: true
 
-  #Expected vs Actual behavior
+  # Proposed Solution
   - type: textarea
-    id: expected
+    id: solution
     attributes:
-      label: Expected behavior
+      label: Proposed Solution
+      description: Describe the feature or improvement you would like to see.
+      placeholder: Explain how you think this feature should work.
     validations:
       required: true
 
+  # Alternatives Considered
   - type: textarea
-    id: actual
+    id: alternatives
     attributes:
-      label: Actual behavior
-    validations:
-      required: true
-
-  # Screenshots
-  - type: textarea
-    id: screenshots
-    attributes:
-      label: Screenshots
-      description: Drag & drop images or paste screenshots here
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you have considered.
+      placeholder: Have you considered other approaches?
     validations:
       required: false
 
-  
-  # Environment info
+  # Additional Context
   - type: textarea
-    id: environment
+    id: context
     attributes:
-      label: Environment / Version info
-      description: OS, browser, app version, device, etc.
+      label: Additional Context
+      description: Add any other context, examples, mockups, or screenshots related to the request.
+      placeholder: Include any supporting information that may help reviewers understand the request.
     validations:
-      required: true
+      required: false
 
-   # Code of Conduct
+  # Code of Conduct
   - type: checkboxes
     id: coc
     attributes:

--- a/.github/ISSUE_TEMPLATE/3-general.yml
+++ b/.github/ISSUE_TEMPLATE/3-general.yml
@@ -1,0 +1,59 @@
+name: "General Issue"
+description: For general discussions or issues
+title: "[General]: "
+labels: ["discussion"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        General issue form. Please provide details below.
+
+  #Description
+  - type: textarea
+    id: description
+    attributes:
+      label: Description / Steps to reproduce
+    validations:
+      required: true
+
+  #Expected vs Actual behavior
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+   # Screenshots
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Drag & drop images or paste screenshots here
+    validations:
+      required: false
+
+  # Environment info
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment / Version info
+    validations:
+      required: true
+
+   # Code of Conduct
+  - type: checkboxes
+    id: coc
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/3-general.yml
+++ b/.github/ISSUE_TEMPLATE/3-general.yml
@@ -1,5 +1,5 @@
 name: "General Issue"
-description: For general discussions or issues
+description: For general discussions, questions, or proposals
 title: "[General]: "
 labels: ["discussion"]
 
@@ -7,37 +7,37 @@ body:
   - type: markdown
     attributes:
       value: |
-        General issue form. Please provide details below.
+        General issue form. Please provide the details below.
 
-  #Description
+  # Type of Issue
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Type
+      description: Select the category that best describes your issue.
+      options:
+        - Question
+        - Proposal
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  # Description
   - type: textarea
     id: description
     attributes:
-      label: Description / Steps to reproduce
+      label: Description
+      description: Please provide details about your question, proposal, or discussion topic.
     validations:
       required: true
 
-  #Expected vs Actual behavior
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected behavior
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual
-    attributes:
-      label: Actual behavior
-    validations:
-      required: true
-
-   # Screenshots
+  # Screenshots
   - type: textarea
     id: screenshots
     attributes:
       label: Screenshots
-      description: Drag & drop images or paste screenshots here
+      description: Drag & drop images or paste screenshots here, if applicable.
     validations:
       required: false
 
@@ -46,10 +46,11 @@ body:
     id: environment
     attributes:
       label: Environment / Version info
+      description: Provide relevant environment details if applicable.
     validations:
-      required: true
+      required: false
 
-   # Code of Conduct
+  # Code of Conduct
   - type: checkboxes
     id: coc
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: "Discussions"
+    url: https://github.com/ms-club-sliit/msclubwebsite-v3/discussions
+    about: Ask questions or discuss ideas here


### PR DESCRIPTION
## Summary
This PR completes the GitHub Issue Templates setup and links it to the tracking issue.

## Closes
Closes #63 

## Changes
- Added Bug Report template
- Added Feature Request template
- Added General Issue template
- Added config.yml to enforce template usage and disable blank issues

## Notes
If any changes are required, I’m happy to make the necessary updates.
